### PR TITLE
Exclude sounds folder from encrypting

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ fn encrypt_from_path(
         "manifest.json",
         "bug_pack_icon.{png,jpg}",
         "texts/**/*",
+        "sounds/**/*",
     ];
 
     let mut contents_json = json!({


### PR DESCRIPTION
This change is needed because minecraft can't load encrypted sounds for some reason.